### PR TITLE
update dependency name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ package-lock.json
 **/lib/bs
 **/lib/ocaml
 **/.merlin
+_esy/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Exposed as `ReactNativePicker` module.
 ## Installation
 
 When
-[`@react-native-picker/picker"`](https://github.com/react-native-picker/picker)
+[`@react-native-picker/picker`](https://github.com/react-native-picker/picker)
 is properly installed & configured by following their installation instructions,
 you can install the bindings:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Exposed as `ReactNativePicker` module.
 ## Installation
 
 When
-[`@react-native-picker/picker`](https://github.com/react-native-picker/picker)
+[`@react-native-picker/picker"`](https://github.com/react-native-picker/picker)
 is properly installed & configured by following their installation instructions,
 you can install the bindings:
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@react-native-community/picker": "^1.9.0"
+    "@react-native-picker/picker": "^1.9.0"
   },
   "repository": "https://github.com/reason-react-native/picker.git",
   "license": "MIT",

--- a/src/ReactNativePicker.re
+++ b/src/ReactNativePicker.re
@@ -1,7 +1,7 @@
 open ReactNative;
 include NativeElement;
 
-[@react.component] [@bs.module "@react-native-community/picker"]
+[@react.component] [@bs.module "@react-native-picker/picker"]
 external make:
   (
     ~ref: ref=?,
@@ -85,7 +85,7 @@ external make:
 
 module Item = {
   [@react.component]
-  [@bs.module "@react-native-community/picker"]
+  [@bs.module "@react-native-picker/picker"]
   [@bs.scope "Picker"]
   external make:
     (

--- a/src/ReactNativePicker.re
+++ b/src/ReactNativePicker.re
@@ -90,7 +90,7 @@ module Item = {
   external make:
     (
       ~value: 'a=?,
-      ~label: string,
+      ~label: string=?,
       ~color: ReactNative.Color.t=?,
       ~testID: string=?
     ) =>

--- a/src/ReactNativePickerIOS.re
+++ b/src/ReactNativePickerIOS.re
@@ -83,7 +83,7 @@ module Item = {
   external make:
     (
       ~value: 'a=?,
-      ~label: string,
+      ~label: string=?,
       ~color: ReactNative.Color.t=?,
       ~testID: string=?
     ) =>

--- a/src/ReactNativePickerIOS.re
+++ b/src/ReactNativePickerIOS.re
@@ -78,7 +78,7 @@ external make:
 
 module Item = {
   [@react.component]
-  [@bs.module "@react-native-community/picker"]
+  [@bs.module "@react-native-picker/picker"]
   [@bs.scope "PickerIOS"]
   external make:
     (

--- a/src/ReactNativePickerIOS.re
+++ b/src/ReactNativePickerIOS.re
@@ -1,7 +1,7 @@
 open ReactNative;
 include NativeElement;
 
-[@react.component] [@bs.module "@react-native-picker/picker"]
+[@react.component] [@bs.module "@react-native-community/picker"]
 external make:
   (
     ~ref: ref=?,
@@ -83,7 +83,7 @@ module Item = {
   external make:
     (
       ~value: 'a=?,
-      ~label: string=?,
+      ~label: string,
       ~color: ReactNative.Color.t=?,
       ~testID: string=?
     ) =>

--- a/src/ReactNativePickerIOS.re
+++ b/src/ReactNativePickerIOS.re
@@ -1,7 +1,7 @@
 open ReactNative;
 include NativeElement;
 
-[@react.component] [@bs.module "@react-native-community/picker"]
+[@react.component] [@bs.module "@react-native-picker/picker"]
 external make:
   (
     ~ref: ref=?,


### PR DESCRIPTION
Binding target name needs to be updated. Its now

```
[@bs.module "@react-native-picker/picker"]
```

I have also update the Item module `label` property which should be optional per typing

```
(JSX attribute) PickerItemProps.label?: string
```
Updated is:
```
module Item = {
  @react.component
  @bs.module("@react-native-picker/picker")
  @bs.scope("PickerIOS")
  external make: (
    ~value: 'a=?,
    ~label: string=?,
    ~color: ReactNative.Color.t=?,
    ~testID: string=?,
  ) => React.element = "Item"
}
```